### PR TITLE
Add shift labels and rostered employees to job calendar

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -34,6 +34,20 @@ body {
   align-items: center;
   gap: 10px;
 }
+.jobsite-grid-wrapper {
+  display: flex;
+  align-items: flex-start;
+}
+.shift-labels {
+  display: flex;
+  flex-direction: column;
+  margin-right: 4px;
+  font-size: 12px;
+}
+.shift-labels div {
+  height: 20px;
+  line-height: 20px;
+}
 .jobsite-grid {
   display: grid;
   grid-template-columns: repeat(365, 20px);
@@ -45,4 +59,22 @@ body {
   width: 20px;
   height: 20px;
   border: 1px solid #eee;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+}
+.jobsite-cell.start,
+.jobsite-cell.end,
+.jobsite-cell.start-span,
+.jobsite-cell.end-span {
+  background: #00ff00;
+}
+.jobsite-cell.middle {
+  background: #ccffcc;
+}
+.jobsite-cell.start,
+.jobsite-cell.end {
+  border: 2px solid #006400;
 }


### PR DESCRIPTION
## Summary
- Color job start and end shifts green with light green between to show job span
- Label day and night rows, show rig employee roster, and display worker IDs in each shift cell

## Testing
- `node app.js` *(fails: ReferenceError: document is not defined)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b037b93da8832687c5b1f98e2bb12f