### PR TITLE
Highlight job start/stop days and per-shift staffing

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,9 +24,10 @@
       </select>
     </label>
     <label>
-      Crew size per job:
-      <select id="crew-size" disabled>
-        <option value="2">2 employees per job</option>
+      Employees per shift:
+      <select id="crew-size">
+        <option value="1">1 employee per shift</option>
+        <option value="2">2 employees per shift</option>
       </select>
     </label>
     <button id="run-simulation">Run Simulation</button>

--- a/styles.css
+++ b/styles.css
@@ -65,16 +65,15 @@ body {
   justify-content: center;
   font-size: 10px;
 }
-.jobsite-cell.start,
-.jobsite-cell.end,
-.jobsite-cell.start-span,
-.jobsite-cell.end-span {
-  background: #00ff00;
+.jobsite-cell.day {
+  border-color: #fff9c4;
 }
-.jobsite-cell.middle {
-  background: #ccffcc;
+.jobsite-cell.night {
+  border-color: #ffe0b2;
 }
-.jobsite-cell.start,
+.jobsite-cell.start {
+  background: #90ee90;
+}
 .jobsite-cell.end {
-  border: 2px solid #006400;
+  background: #ffcccb;
 }


### PR DESCRIPTION
## Summary
- Color-code job start (green) and stop (light red) days while leaving middle days unstyled
- Label day/night rows and outline shifts in yellow/orange with assigned employee IDs
- Allow selecting number of employees per shift (default 1) and display roster with empty spots

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b057e20f4c8326bfbca160f01a4a03