### PR TITLE
Add employee job summary and week labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,10 @@
     <button id="add-jobsite">Add Jobsite</button>
     <div id="jobsites-list"></div>
   </section>
+  <section id="employee-summary">
+    <h2>Employee Job Summary</h2>
+    <table id="employee-job-table"></table>
+  </section>
   <script src="app.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -77,3 +77,32 @@ body {
 .jobsite-cell.end {
   background: #ffcccb;
 }
+
+.grid-container {
+  display: flex;
+  flex-direction: column;
+}
+
+.week-labels {
+  display: grid;
+  grid-template-columns: repeat(365, 20px);
+  font-size: 10px;
+}
+
+.week-labels div {
+  text-align: center;
+  height: 20px;
+  line-height: 20px;
+}
+
+#employee-job-table {
+  border-collapse: collapse;
+  margin-top: 10px;
+}
+
+#employee-job-table th,
+#employee-job-table td {
+  border: 1px solid #ccc;
+  padding: 4px;
+  font-size: 12px;
+}


### PR DESCRIPTION
## Summary
- Distribute employees evenly across jobsites and start rotations on night shift
- Show weekly labels beneath jobsite calendars
- Provide an employee job summary table with hover details on job occurrences

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b081e4854483268191cd88ada7b8a8