### PR TITLE
Enable sortable employee summary and count start/end days

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -106,3 +106,15 @@ body {
   padding: 4px;
   font-size: 12px;
 }
+
+#employee-job-table th {
+  cursor: pointer;
+}
+
+#employee-job-table th.sorted-asc::after {
+  content: ' \25B2';
+}
+
+#employee-job-table th.sorted-desc::after {
+  content: ' \25BC';
+}


### PR DESCRIPTION
## Summary
- Only include job start and end days when computing employee job counts
- Allow sorting the employee job summary table by clicking any column header
- Add styles to highlight sortable headers and display sort direction arrows

## Testing
- `node --check app.js`
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68b085719a848326bd6639a5fcace9f8