### PR TITLE
Add flex crew option and proficiency targets

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
       Employees per shift:
       <select id="crew-size">
         <option value="1">1 employee per shift</option>
+        <option value="1.5">1.5 employees per shift (flex)</option>
         <option value="2">2 employees per shift</option>
       </select>
     </label>

--- a/styles.css
+++ b/styles.css
@@ -118,3 +118,12 @@ body {
 #employee-job-table th.sorted-desc::after {
   content: ' \25BC';
 }
+
+.proficiency-met {
+  color: green;
+  font-weight: bold;
+}
+
+.proficiency-miss {
+  color: red;
+}


### PR DESCRIPTION
## Summary
- allow flexible 1.5 employees per shift and pull extra workers from vacation pool
- support proficiency targets for each job with input field
- show proficiency status in employee summary table with checkmark or deficit

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b08ac17ff083268ba3c14d3179c476