### PR TITLE
Add configurable jobsite percentage weighting

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
   </section>
   <section id="jobsites">
     <h2>Jobsites</h2>
+    <div id="jobsite-percentage-total">Total: 0%</div>
     <button id="add-jobsite">Add Jobsite</button>
     <div id="jobsites-list"></div>
   </section>

--- a/styles.css
+++ b/styles.css
@@ -20,6 +20,31 @@ body {
 .job-row, .jobsite {
   margin-top: 10px;
 }
+
+.jobsite {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.jobsite-percent {
+  display: flex;
+  align-items: center;
+}
+
+.jobsite-percent input {
+  width: 50px;
+}
+
+.jobsite-content {
+  display: flex;
+  flex-direction: column;
+}
+
+#jobsite-percentage-total {
+  margin-top: 10px;
+  font-weight: bold;
+}
 .job-row input {
   width: 60px;
 }


### PR DESCRIPTION
## Summary
- Add editable percentage controls for each jobsite with a running total indicator.
- Persist jobsite percentage in configuration and rebalance percentages when sites change.
- Weight job placement by jobsite percentage during simulation.

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b08e2b568c832691f229a98f4ce740